### PR TITLE
Feat/export: add PDF and Excel export to clients view; leave placeholder in other views

### DIFF
--- a/src/main/resources/templates/clientes/edicion.html
+++ b/src/main/resources/templates/clientes/edicion.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Clientes', 'Editar', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Clientes', 'Editar', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
 
     <div class="card shadow-sm p-4">

--- a/src/main/resources/templates/clientes/index.html
+++ b/src/main/resources/templates/clientes/index.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Clientes', 'Listado', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="fragments/layout :: layoutBase('Clientes', 'Listado', ~{::contenido}, ~{::scripts})">
+
 <th:block th:fragment="contenido">
     <div class="row">
         <div class="col-12">
@@ -14,6 +16,19 @@
                         <i class="fas fa-plus me-1"></i>
                         Nuevo
                     </a>
+                </div>
+
+                <div class="px-4 pt-3">
+                    <div class="d-flex gap-2">
+                        <button id="btn-exportar-pdf" class="btn btn-danger btn-sm mb-0">
+                            <i class="fa-solid fa-file-pdf me-1"></i>
+                            PDF
+                        </button>
+                        <button id="btn-exportar-excel" class="btn btn-success btn-sm mb-0">
+                            <i class="fa-solid fa-file-excel me-1"></i>
+                            Excel
+                        </button>
+                    </div>
                 </div>
 
                 <div class="card-body px-0 pt-0 pb-2">
@@ -69,6 +84,186 @@
             </div>
         </div>
     </div>
-    <div th:replace="fragments/datatable-script :: datatableScript('tabla-clientes')"></div>
+</th:block>
+
+<th:block th:fragment="scripts">
+    <th:block th:replace="fragments/datatable-script :: datatableScript('tabla-clientes')"/>
+
+    <!-- jsPDF + autoTable -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
+
+    <!-- ExcelJS -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/exceljs/4.3.0/exceljs.min.js"></script>
+
+    <script>
+        // ===================== Export to PDF =====================
+        document.getElementById('btn-exportar-pdf').addEventListener('click', () => {
+            const { jsPDF } = window.jspdf;
+            const doc = new jsPDF();
+            const table = $('#tabla-clientes').DataTable();
+            const headers = [];
+            const data = [];
+
+            $('#tabla-clientes thead th').each(function (index) {
+                if (index < $('#tabla-clientes thead th').length - 1) {
+                    headers.push($(this).text().trim());
+                }
+            });
+
+            table.rows({ search: 'applied' }).every(function () {
+                const row = this.data();
+                const rowData = [];
+                for (let i = 0; i < row.length - 1; i++) {
+                    rowData.push($(row[i]).text() || row[i]);
+                }
+                data.push(rowData);
+            });
+
+            const pageWidth = doc.internal.pageSize.getWidth();
+            const margin = 15;
+
+            const now = new Date();
+            const dateText = now.toLocaleDateString('es-PE', {
+                day: 'numeric',
+                month: 'short',
+                year: 'numeric'
+            }).replace('.', '');
+
+            const timeText = now.toLocaleTimeString('es-PE', {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+            }).toLowerCase();
+
+            doc.setFontSize(11);
+            doc.setTextColor('#000000');
+            doc.text(dateText, margin, 15);
+            doc.text(timeText, pageWidth - margin, 15, { align: 'right' });
+
+            doc.setFontSize(14);
+            doc.setFont(undefined, 'bold');
+            doc.text('Lista de clientes', pageWidth / 2, 15, { align: 'center' });
+
+            doc.autoTable({
+                head: [headers],
+                body: data,
+                startY: 22,
+                headStyles: {
+                    fillColor: '#344767',
+                    textColor: '#ffffff',
+                    valign: 'middle',
+                    fontStyle: 'bold',
+                    lineColor: '#2c3e50',
+                    lineWidth: 0.2
+                },
+                styles: {
+                    fontSize: 9,
+                    cellPadding: 3,
+                    textColor: '#000000',
+                    lineColor: '#cccccc',
+                    lineWidth: 0.1
+                },
+                theme: 'grid'
+            });
+
+            doc.save('clientes.pdf');
+        });
+        // =================== End Export to PDF ===================
+
+        // ===================== Export to Excel =====================
+        document.getElementById('btn-exportar-excel').addEventListener('click', async () => {
+            const table = $('#tabla-clientes').DataTable();
+            const headers = [];
+            const data = [];
+
+            $('#tabla-clientes thead th').each(function (i) {
+                if (i < $('#tabla-clientes thead th').length - 1) {
+                    headers.push($(this).text().trim());
+                }
+            });
+
+            table.rows({ search: 'applied' }).every(function () {
+                const row = this.data();
+                const rowData = [];
+                for (let i = 0; i < row.length - 1; i++) {
+                    rowData.push($(row[i]).text().trim() || row[i]);
+                }
+                data.push(rowData);
+            });
+
+            const workbook = new ExcelJS.Workbook();
+            const sheet = workbook.addWorksheet('Clientes');
+
+            const now = new Date();
+            const dateText = now.toLocaleDateString('es-PE', {
+                day: 'numeric', month: 'short', year: 'numeric'
+            }).replace('.', '');
+            const timeText = now.toLocaleTimeString('es-PE', {
+                hour: 'numeric', minute: '2-digit', hour12: true
+            }).toLowerCase();
+
+            sheet.mergeCells('C1', 'D1');
+            sheet.getCell('A1').value = `${dateText}`;
+            sheet.getCell('C1').value = 'Lista de clientes';
+            sheet.getCell('F1').value = `${timeText}`;
+
+            sheet.getCell('A1').font = { bold: true };
+            sheet.getCell('C1').font = { bold: true, size: 14 };
+            sheet.getCell('C1').alignment = { horizontal: 'center' };
+            sheet.getCell('F1').font = { bold: true };
+            sheet.getCell('F1').alignment = { horizontal: 'right' };
+
+            sheet.addRow([]);
+            const headerRow = sheet.addRow(headers);
+
+            headerRow.eachCell((cell) => {
+                cell.fill = {
+                    type: 'pattern',
+                    pattern: 'solid',
+                    fgColor: { argb: 'FF344767' }
+                };
+                cell.font = { color: { argb: 'FFFFFFFF' }, bold: true };
+                cell.alignment = { vertical: 'middle', horizontal: 'center' };
+                cell.border = {
+                    top: { style: 'thin', color: { argb: 'FF2C3E50' } },
+                    bottom: { style: 'thin', color: { argb: 'FF2C3E50' } },
+                    left: { style: 'thin', color: { argb: 'FF2C3E50' } },
+                    right: { style: 'thin', color: { argb: 'FF2C3E50' } }
+                };
+            });
+
+            data.forEach(rowData => {
+                const row = sheet.addRow(rowData);
+                row.eachCell(cell => {
+                    cell.font = { color: { argb: 'FF000000' } };
+                    cell.alignment = { vertical: 'middle', horizontal: 'left' };
+                    cell.border = {
+                        top: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+                        bottom: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+                        left: { style: 'thin', color: { argb: 'FFCCCCCC' } },
+                        right: { style: 'thin', color: { argb: 'FFCCCCCC' } }
+                    };
+                });
+            });
+
+            sheet.columns.forEach(column => {
+                let maxLength = 10;
+                column.eachCell({ includeEmpty: true }, cell => {
+                    const len = cell.value ? cell.value.toString().length : 0;
+                    if (len > maxLength) maxLength = len;
+                });
+                column.width = maxLength + 2;
+            });
+
+            const buffer = await workbook.xlsx.writeBuffer();
+            const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+            const link = document.createElement('a');
+            link.href = URL.createObjectURL(blob);
+            link.download = 'clientes.xlsx';
+            link.click();
+        });
+        // ================== End Export to Excel ==================
+    </script>
 </th:block>
 </html>

--- a/src/main/resources/templates/clientes/nuevo.html
+++ b/src/main/resources/templates/clientes/nuevo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Clientes', 'Nuevo', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Clientes', 'Nuevo', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
 
     <div class="card shadow-sm p-4">

--- a/src/main/resources/templates/cuenta/perfil.html
+++ b/src/main/resources/templates/cuenta/perfil.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Cuenta', 'Perfil', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Cuenta', 'Perfil', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
 	<div class="row">
 		<div class="col-md-8">

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" xmlns:th="http://www.thymeleaf.org" th:fragment="layoutBase(controlador, accion, contenido)">
+<html lang="es" xmlns:th="http://www.thymeleaf.org" th:fragment="layoutBase(controlador, accion, contenido, scripts)">
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -13,245 +13,247 @@
 	<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
 <body class="g-sidenav-show   bg-gray-100">
-<div class="min-height-300 bg-dark position-absolute w-100"></div>
-<aside class="sidenav bg-white navbar navbar-vertical navbar-expand-xs border-0 border-radius-xl my-3 fixed-start ms-4 " id="sidenav-main">
-	<div class="sidenav-header">
-		<i class="fas fa-times p-3 cursor-pointer text-secondary opacity-5 position-absolute end-0 top-0 d-none d-xl-none" aria-hidden="true" id="iconSidenav"></i>
-		<a class="navbar-brand m-0" th:href="@{/}">
-			<img src="/assets/img/logo-ct-dark.png" width="26px" height="26px" class="navbar-brand-img h-100" alt="main_logo">
-			<span class="ms-1 font-weight-bold">Sistema</span>
-		</a>
-	</div>
-	<hr class="horizontal dark mt-0">
-	<div class="collapse navbar-collapse  w-auto " id="sidenav-scrollbar">
-		<ul class="navbar-nav">
-			<li class="nav-item">
-				<a class="nav-link" th:classappend="${uri == '/' ? 'active' : ''}" th:href="@{/}">
-					<div class="sidebar-icon-box ms-2 me-3">
-						<i class="fa-solid fa-gauge text-dark text-sm opacity-10"></i>
-					</div>
-					<span class="nav-link-text ms-1">Dashboard</span>
-				</a>
-			</li>
-
-			<div th:if="${session.mostrarRegistro}">
-				<li class="nav-item">
-					<a class="nav-link" th:classappend="${uri == '/registros' ? 'active' : ''}"
-					   th:href="@{/registros}">
-						<div class="sidebar-icon-box ms-2 me-3">
-							<i class="fa-solid fa-id-card text-dark text-sm opacity-10"></i>
-						</div>
-						<span class="nav-link-text ms-1">Registro RUC10</span>
-					</a>
-				</li>
-			</div>
-
-			<div id="clientes" th:if="${session.mostrarClientes}">
-				<li class="nav-item">
-					<a class="nav-link" th:classappend="${uri == '/clientes' ? 'active' : ''}"
-					   th:href="@{/clientes}">
-						<div class="sidebar-icon-box ms-2 me-3">
-							<i class="fa-solid fa-user-tie text-dark text-sm opacity-10"></i>
-						</div>
-						<span class="nav-link-text ms-1">Clientes</span>
-					</a>
-				</li>
-			</div>
-
-			<div id="planes" th:if="${session.mostrarPlanes}">
-				<li class="nav-item">
-					<a class="nav-link" th:classappend="${uri == '/planes' ? 'active' : ''}" th:href="@{/planes}">
-						<div class="sidebar-icon-box ms-2 me-3">
-							<i class="fa-solid fa-layer-group text-dark text-sm opacity-10"></i>
-						</div>
-						<span class="nav-link-text ms-1">Planes</span>
-					</a>
-				</li>
-			</div>
-
-			<div id="promociones" th:if="${session.mostrarPromociones}">
-				<li class="nav-item">
-					<a class="nav-link" th:classappend="${uri == '/promociones' ? 'active' : ''}"
-					   th:href="@{/promociones}">
-						<div class="sidebar-icon-box ms-2 me-3">
-							<i class="fa-solid fa-gift text-dark text-sm opacity-10"></i>
-						</div>
-						<span class="nav-link-text ms-1">Promociones</span>
-					</a>
-				</li>
-			</div>
-
-			<div id="usuarios" th:if="${session.mostrarUsuarios}">
-				<li class="nav-item">
-					<a class="nav-link" th:classappend="${uri == '/usuarios' ? 'active' : ''}"
-					   th:href="@{/usuarios}">
-						<div class="sidebar-icon-box ms-2 me-3">
-							<i class="fa-solid fa-users text-dark text-sm opacity-10"></i>
-						</div>
-						<span class="nav-link-text ms-1">Usuarios</span>
-					</a>
-				</li>
-			</div>
-
-			<li class="nav-item mt-3">
-				<h6 class="ps-4 ms-2 text-uppercase text-xs font-weight-bolder opacity-6">Cuenta</h6>
-			</li>
-
-			<li class="nav-item">
-				<a class="nav-link" th:classappend="${uri == '/cuenta/perfil' ? 'active' : ''}" th:href="@{/cuenta/perfil}">
-					<div class="sidebar-icon-box ms-2 me-3">
-						<i class="fa-solid fa-user text-dark text-sm opacity-10"></i>
-					</div>
-					<span class="nav-link-text ms-1">Perfil</span>
-				</a>
-			</li>
-
-			<li class="nav-item">
-				<a class="nav-link text-danger" th:href="@{/cuenta/cerrarSesion}">
-					<div class="sidebar-icon-box ms-2 me-3">
-						<i class="fa-solid fa-arrow-right-from-bracket text-danger text-sm"></i>
-					</div>
-					<span class="nav-link-text ms-1">Cerrar sesión</span>
-				</a>
-			</li>
-		</ul>
-	</div>
-</aside>
-
-<main class="main-content position-relative border-radius-lg min-vh-100">
-	<!-- Navbar -->
-	<nav class="navbar navbar-main navbar-expand-lg px-0 mx-4 shadow-none border-radius-xl " id="navbarBlur"
-		 data-scroll="false">
-		<div class="container-fluid py-1 px-3">
-			<nav aria-label="breadcrumb">
-				<ol class="breadcrumb bg-transparent mb-0 pb-0 pt-1 px-0 me-sm-6 me-5">
-					<li class="breadcrumb-item text-sm">
-						<a class="opacity-5 text-white" th:href="@{/}">Sistema</a>
-					</li>
-					<li class="breadcrumb-item text-sm text-white active" aria-current="page"
-						th:text="${controlador}"></li>
-				</ol>
-				<h6 class="font-weight-bolder text-white mb-0" th:text="${accion}"></h6>
-			</nav>
-			<div class="collapse navbar-collapse mt-sm-0 mt-2 me-md-0 me-sm-4" id="navbar">
-				<div class="ms-md-auto pe-md-3 d-flex align-items-center">
-					<div class="input-group">
-							<span class="input-group-text text-body"><i class="fas fa-search"
-																		aria-hidden="true"></i></span>
-						<input type="text" class="form-control" placeholder="Buscar...">
-					</div>
-				</div>
-				<ul class="navbar-nav  justify-content-end">
-					<li class="nav-item d-xl-none ps-3 d-flex align-items-center">
-						<a href="javascript:;" class="nav-link text-white p-0" id="iconNavbarSidenav">
-							<div class="sidenav-toggler-inner">
-								<i class="sidenav-toggler-line bg-white"></i>
-								<i class="sidenav-toggler-line bg-white"></i>
-								<i class="sidenav-toggler-line bg-white"></i>
-							</div>
-						</a>
-					</li>
-					<li class="nav-item px-3 d-flex align-items-center">
-						<a href="javascript:;" class="nav-link text-white p-0">
-							<i class="fa fa-cog fixed-plugin-button-nav cursor-pointer"></i>
-						</a>
-					</li>
-				</ul>
-			</div>
-		</div>
-	</nav>
-	<!-- End Navbar -->
-	<div class="container-fluid py-4" th:insert="~{::contenido}">
-
-	</div>
-</main>
-<div class="fixed-plugin">
-	<div class="card shadow-lg">
-		<div class="card-header pb-0 pt-3 ">
-			<div class="float-start">
-				<h5 class="mt-3 mb-0">Configurador</h5>
-				<p>Consulta las opciones del panel.</p>
-			</div>
-			<div class="float-end mt-4">
-				<button class="btn btn-link text-dark p-0 fixed-plugin-close-button">
-					<i class="fa fa-close"></i>
-				</button>
-			</div>
-			<!-- End Toggle Button -->
-		</div>
-		<hr class="horizontal dark my-1">
-		<div class="card-body pt-sm-3 pt-0 overflow-auto">
-			<!-- Sidebar Backgrounds -->
-			<div>
-				<h6 class="mb-0">Colores de la barra lateral</h6>
-			</div>
-			<a href="javascript:void(0)" class="switch-trigger background-color">
-				<div class="badge-colors my-2 text-start">
-						<span class="badge filter bg-gradient-primary active" data-color="primary"
-							  onclick="sidebarColor(this)"></span>
-					<span class="badge filter bg-gradient-dark" data-color="dark"
-						  onclick="sidebarColor(this)"></span>
-					<span class="badge filter bg-gradient-info" data-color="info"
-						  onclick="sidebarColor(this)"></span>
-					<span class="badge filter bg-gradient-success" data-color="success"
-						  onclick="sidebarColor(this)"></span>
-					<span class="badge filter bg-gradient-warning" data-color="warning"
-						  onclick="sidebarColor(this)"></span>
-					<span class="badge filter bg-gradient-danger" data-color="danger"
-						  onclick="sidebarColor(this)"></span>
-				</div>
+	<div class="min-height-300 bg-dark position-absolute w-100"></div>
+	<aside class="sidenav bg-white navbar navbar-vertical navbar-expand-xs border-0 border-radius-xl my-3 fixed-start ms-4 " id="sidenav-main">
+		<div class="sidenav-header">
+			<i class="fas fa-times p-3 cursor-pointer text-secondary opacity-5 position-absolute end-0 top-0 d-none d-xl-none" aria-hidden="true" id="iconSidenav"></i>
+			<a class="navbar-brand m-0" th:href="@{/}">
+				<img src="/assets/img/logo-ct-dark.png" width="26px" height="26px" class="navbar-brand-img h-100" alt="main_logo">
+				<span class="ms-1 font-weight-bold">Sistema</span>
 			</a>
-			<!-- Sidenav Type -->
-			<div class="mt-3">
-				<h6 class="mb-0">Tipo de barra lateral</h6>
-				<p class="text-sm">Elige entre 2 tipos diferentes de barra lateral.</p>
-			</div>
-			<div class="d-flex">
-				<button class="btn bg-gradient-primary w-100 px-3 mb-2 active me-2" data-class="bg-white"
-						onclick="sidebarType(this)">Blanca</button>
-				<button class="btn bg-gradient-primary w-100 px-3 mb-2" data-class="bg-default"
-						onclick="sidebarType(this)">Oscura</button>
-			</div>
-			<p class="text-sm d-xl-none d-block mt-2">Solo puedes cambiar el tipo de barra lateral en vista de escritorio.</p>
-			<!-- Navbar Fixed -->
-			<div class="d-flex my-3">
-				<h6 class="mb-0">Barra de navegación fija</h6>
-				<div class="form-check form-switch ps-0 ms-auto my-auto">
-					<input class="form-check-input mt-1 ms-auto" type="checkbox" id="navbarFixed"
-						   onclick="navbarFixed(this)">
+		</div>
+		<hr class="horizontal dark mt-0">
+		<div class="collapse navbar-collapse  w-auto " id="sidenav-scrollbar">
+			<ul class="navbar-nav">
+				<li class="nav-item">
+					<a class="nav-link" th:classappend="${uri == '/' ? 'active' : ''}" th:href="@{/}">
+						<div class="sidebar-icon-box ms-2 me-3">
+							<i class="fa-solid fa-gauge text-dark text-sm opacity-10"></i>
+						</div>
+						<span class="nav-link-text ms-1">Dashboard</span>
+					</a>
+				</li>
+
+				<div th:if="${session.mostrarRegistro}">
+					<li class="nav-item">
+						<a class="nav-link" th:classappend="${uri == '/registros' ? 'active' : ''}"
+						   th:href="@{/registros}">
+							<div class="sidebar-icon-box ms-2 me-3">
+								<i class="fa-solid fa-id-card text-dark text-sm opacity-10"></i>
+							</div>
+							<span class="nav-link-text ms-1">Registro RUC10</span>
+						</a>
+					</li>
+				</div>
+
+				<div id="clientes" th:if="${session.mostrarClientes}">
+					<li class="nav-item">
+						<a class="nav-link" th:classappend="${uri == '/clientes' ? 'active' : ''}"
+						   th:href="@{/clientes}">
+							<div class="sidebar-icon-box ms-2 me-3">
+								<i class="fa-solid fa-user-tie text-dark text-sm opacity-10"></i>
+							</div>
+							<span class="nav-link-text ms-1">Clientes</span>
+						</a>
+					</li>
+				</div>
+
+				<div id="planes" th:if="${session.mostrarPlanes}">
+					<li class="nav-item">
+						<a class="nav-link" th:classappend="${uri == '/planes' ? 'active' : ''}" th:href="@{/planes}">
+							<div class="sidebar-icon-box ms-2 me-3">
+								<i class="fa-solid fa-layer-group text-dark text-sm opacity-10"></i>
+							</div>
+							<span class="nav-link-text ms-1">Planes</span>
+						</a>
+					</li>
+				</div>
+
+				<div id="promociones" th:if="${session.mostrarPromociones}">
+					<li class="nav-item">
+						<a class="nav-link" th:classappend="${uri == '/promociones' ? 'active' : ''}"
+						   th:href="@{/promociones}">
+							<div class="sidebar-icon-box ms-2 me-3">
+								<i class="fa-solid fa-gift text-dark text-sm opacity-10"></i>
+							</div>
+							<span class="nav-link-text ms-1">Promociones</span>
+						</a>
+					</li>
+				</div>
+
+				<div id="usuarios" th:if="${session.mostrarUsuarios}">
+					<li class="nav-item">
+						<a class="nav-link" th:classappend="${uri == '/usuarios' ? 'active' : ''}"
+						   th:href="@{/usuarios}">
+							<div class="sidebar-icon-box ms-2 me-3">
+								<i class="fa-solid fa-users text-dark text-sm opacity-10"></i>
+							</div>
+							<span class="nav-link-text ms-1">Usuarios</span>
+						</a>
+					</li>
+				</div>
+
+				<li class="nav-item mt-3">
+					<h6 class="ps-4 ms-2 text-uppercase text-xs font-weight-bolder opacity-6">Cuenta</h6>
+				</li>
+
+				<li class="nav-item">
+					<a class="nav-link" th:classappend="${uri == '/cuenta/perfil' ? 'active' : ''}" th:href="@{/cuenta/perfil}">
+						<div class="sidebar-icon-box ms-2 me-3">
+							<i class="fa-solid fa-user text-dark text-sm opacity-10"></i>
+						</div>
+						<span class="nav-link-text ms-1">Perfil</span>
+					</a>
+				</li>
+
+				<li class="nav-item">
+					<a class="nav-link text-danger" th:href="@{/cuenta/cerrarSesion}">
+						<div class="sidebar-icon-box ms-2 me-3">
+							<i class="fa-solid fa-arrow-right-from-bracket text-danger text-sm"></i>
+						</div>
+						<span class="nav-link-text ms-1">Cerrar sesión</span>
+					</a>
+				</li>
+			</ul>
+		</div>
+	</aside>
+
+	<main class="main-content position-relative border-radius-lg min-vh-100">
+		<!-- Navbar -->
+		<nav class="navbar navbar-main navbar-expand-lg px-0 mx-4 shadow-none border-radius-xl " id="navbarBlur"
+			 data-scroll="false">
+			<div class="container-fluid py-1 px-3">
+				<nav aria-label="breadcrumb">
+					<ol class="breadcrumb bg-transparent mb-0 pb-0 pt-1 px-0 me-sm-6 me-5">
+						<li class="breadcrumb-item text-sm">
+							<a class="opacity-5 text-white" th:href="@{/}">Sistema</a>
+						</li>
+						<li class="breadcrumb-item text-sm text-white active" aria-current="page"
+							th:text="${controlador}"></li>
+					</ol>
+					<h6 class="font-weight-bolder text-white mb-0" th:text="${accion}"></h6>
+				</nav>
+				<div class="collapse navbar-collapse mt-sm-0 mt-2 me-md-0 me-sm-4" id="navbar">
+					<div class="ms-md-auto pe-md-3 d-flex align-items-center">
+						<div class="input-group">
+								<span class="input-group-text text-body"><i class="fas fa-search"
+																			aria-hidden="true"></i></span>
+							<input type="text" class="form-control" placeholder="Buscar...">
+						</div>
+					</div>
+					<ul class="navbar-nav  justify-content-end">
+						<li class="nav-item d-xl-none ps-3 d-flex align-items-center">
+							<a href="javascript:;" class="nav-link text-white p-0" id="iconNavbarSidenav">
+								<div class="sidenav-toggler-inner">
+									<i class="sidenav-toggler-line bg-white"></i>
+									<i class="sidenav-toggler-line bg-white"></i>
+									<i class="sidenav-toggler-line bg-white"></i>
+								</div>
+							</a>
+						</li>
+						<li class="nav-item px-3 d-flex align-items-center">
+							<a href="javascript:;" class="nav-link text-white p-0">
+								<i class="fa fa-cog fixed-plugin-button-nav cursor-pointer"></i>
+							</a>
+						</li>
+					</ul>
 				</div>
 			</div>
-			<hr class="horizontal dark my-sm-4">
-			<div class="mt-2 mb-5 d-flex">
-				<h6 class="mb-0">Claro / Oscuro</h6>
-				<div class="form-check form-switch ps-0 ms-auto my-auto">
-					<input class="form-check-input mt-1 ms-auto" type="checkbox" id="dark-version"
-						   onclick="darkMode(this)">
+		</nav>
+		<!-- End Navbar -->
+
+		<!-- Content -->
+		<div class="container-fluid py-4" th:insert="~{::contenido}"></div>
+	</main>
+
+	<div class="fixed-plugin">
+		<div class="card shadow-lg">
+			<div class="card-header pb-0 pt-3 ">
+				<div class="float-start">
+					<h5 class="mt-3 mb-0">Configurador</h5>
+					<p>Consulta las opciones del panel.</p>
+				</div>
+				<div class="float-end mt-4">
+					<button class="btn btn-link text-dark p-0 fixed-plugin-close-button">
+						<i class="fa fa-close"></i>
+					</button>
+				</div>
+				<!-- End Toggle Button -->
+			</div>
+			<hr class="horizontal dark my-1">
+			<div class="card-body pt-sm-3 pt-0 overflow-auto">
+				<!-- Sidebar Backgrounds -->
+				<div>
+					<h6 class="mb-0">Colores de la barra lateral</h6>
+				</div>
+				<a href="javascript:void(0)" class="switch-trigger background-color">
+					<div class="badge-colors my-2 text-start">
+							<span class="badge filter bg-gradient-primary active" data-color="primary"
+								  onclick="sidebarColor(this)"></span>
+						<span class="badge filter bg-gradient-dark" data-color="dark"
+							  onclick="sidebarColor(this)"></span>
+						<span class="badge filter bg-gradient-info" data-color="info"
+							  onclick="sidebarColor(this)"></span>
+						<span class="badge filter bg-gradient-success" data-color="success"
+							  onclick="sidebarColor(this)"></span>
+						<span class="badge filter bg-gradient-warning" data-color="warning"
+							  onclick="sidebarColor(this)"></span>
+						<span class="badge filter bg-gradient-danger" data-color="danger"
+							  onclick="sidebarColor(this)"></span>
+					</div>
+				</a>
+				<!-- Sidenav Type -->
+				<div class="mt-3">
+					<h6 class="mb-0">Tipo de barra lateral</h6>
+					<p class="text-sm">Elige entre 2 tipos diferentes de barra lateral.</p>
+				</div>
+				<div class="d-flex">
+					<button class="btn bg-gradient-primary w-100 px-3 mb-2 active me-2" data-class="bg-white"
+							onclick="sidebarType(this)">Blanca</button>
+					<button class="btn bg-gradient-primary w-100 px-3 mb-2" data-class="bg-default"
+							onclick="sidebarType(this)">Oscura</button>
+				</div>
+				<p class="text-sm d-xl-none d-block mt-2">Solo puedes cambiar el tipo de barra lateral en vista de escritorio.</p>
+				<!-- Navbar Fixed -->
+				<div class="d-flex my-3">
+					<h6 class="mb-0">Barra de navegación fija</h6>
+					<div class="form-check form-switch ps-0 ms-auto my-auto">
+						<input class="form-check-input mt-1 ms-auto" type="checkbox" id="navbarFixed"
+							   onclick="navbarFixed(this)">
+					</div>
+				</div>
+				<hr class="horizontal dark my-sm-4">
+				<div class="mt-2 mb-5 d-flex">
+					<h6 class="mb-0">Claro / Oscuro</h6>
+					<div class="form-check form-switch ps-0 ms-auto my-auto">
+						<input class="form-check-input mt-1 ms-auto" type="checkbox" id="dark-version"
+							   onclick="darkMode(this)">
+					</div>
 				</div>
 			</div>
 		</div>
 	</div>
-</div>
 
-<div th:if="${alert}">
-	<div th:utext="${alert}"></div>
-</div>
+	<div th:if="${alert}">
+		<div th:utext="${alert}"></div>
+	</div>
 
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/smooth-scrollbar/8.8.4/smooth-scrollbar.min.js"></script>
-<script>
-	window.PerfectScrollbar = function () { return { destroy() {} }; };
-</script>
-<script src="https://demos.creative-tim.com/argon-dashboard/assets/js/argon-dashboard.min.js"></script>
-<script>
-	var win = navigator.platform.indexOf('Win') > -1;
-    if (win && document.querySelector('#sidenav-scrollbar')) {
-      var options = {
-        damping: '0.5'
-      }
-      Scrollbar.init(document.querySelector('#sidenav-scrollbar'), options);
-    }
-</script>
+	<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/smooth-scrollbar/8.8.4/smooth-scrollbar.min.js"></script>
+	<script>
+		window.PerfectScrollbar = function () { return { destroy() {} }; };
+	</script>
+	<script src="https://demos.creative-tim.com/argon-dashboard/assets/js/argon-dashboard.min.js"></script>
+	<script>
+		var win = navigator.platform.indexOf('Win') > -1;
+		if (win && document.querySelector('#sidenav-scrollbar')) {
+		  var options = {
+			damping: '0.5'
+		  }
+		  Scrollbar.init(document.querySelector('#sidenav-scrollbar'), options);
+		}
+	</script>
+	<div th:replace="${scripts} ?: ~{}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/home/dashboard.html
+++ b/src/main/resources/templates/home/dashboard.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Inicio', 'Dashboard', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Inicio', 'Dashboard', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
 
     <div class="row">

--- a/src/main/resources/templates/planes/index.html
+++ b/src/main/resources/templates/planes/index.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Planes', 'Listado', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="fragments/layout :: layoutBase('Planes', 'Listado', ~{::contenido}, ~{})">
+
 <th:block th:fragment="contenido">
     <div class="row">
         <div class="col-12">
@@ -14,6 +16,20 @@
                         Nuevo
                     </a>
                 </div>
+
+                <div class="px-4 pt-3">
+                    <div class="d-flex gap-2">
+                        <button id="btn-exportar-pdf" class="btn btn-danger btn-sm mb-0">
+                            <i class="fa-solid fa-file-pdf me-1"></i>
+                            PDF
+                        </button>
+                        <button id="btn-exportar-excel" class="btn btn-success btn-sm mb-0">
+                            <i class="fa-solid fa-file-excel me-1"></i>
+                            Excel
+                        </button>
+                    </div>
+                </div>
+
                 <div class="card-body px-0 pt-0 pb-2">
                     <table id="tabla-planes" class="table align-items-center mb-0">
                         <thead>

--- a/src/main/resources/templates/promociones/edicion.html
+++ b/src/main/resources/templates/promociones/edicion.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Promociones', 'Editar', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Promociones', 'Editar', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
 
     <div class="card shadow-sm p-4">

--- a/src/main/resources/templates/promociones/index.html
+++ b/src/main/resources/templates/promociones/index.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Promociones', 'Listado', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org"
+	  th:replace="fragments/layout :: layoutBase('Promociones', 'Listado', ~{::contenido}, ~{})">
+
 <th:block th:fragment="contenido">
 	<div class="row">
 		<div class="col-12">
@@ -14,6 +16,19 @@
 						<i class="fas fa-plus me-1"></i>
 						Nueva
 					</a>
+				</div>
+
+				<div class="px-4 pt-3">
+					<div class="d-flex gap-2">
+						<button id="btn-exportar-pdf" class="btn btn-danger btn-sm mb-0">
+							<i class="fa-solid fa-file-pdf me-1"></i>
+							PDF
+						</button>
+						<button id="btn-exportar-excel" class="btn btn-success btn-sm mb-0">
+							<i class="fa-solid fa-file-excel me-1"></i>
+							Excel
+						</button>
+					</div>
 				</div>
 
 				<div class="card-body px-0 pt-0 pb-2">

--- a/src/main/resources/templates/promociones/nuevo.html
+++ b/src/main/resources/templates/promociones/nuevo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Promociones', 'Nuevo', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Promociones', 'Nuevo', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
 
     <div class="card shadow-sm p-4">

--- a/src/main/resources/templates/registros/actualizar.html
+++ b/src/main/resources/templates/registros/actualizar.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Registros', 'Nuevo', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Registros', 'Nuevo', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
     <div class="card shadow-sm p-4">
         <h5 class="mb-4">

--- a/src/main/resources/templates/registros/index.html
+++ b/src/main/resources/templates/registros/index.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Registros RUC1O', 'Listado', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="fragments/layout :: layoutBase('Registros RUC1O', 'Listado', ~{::contenido}, ~{})">
+
 <th:block th:fragment="contenido">
     <div class="row">
         <div class="col-12">

--- a/src/main/resources/templates/registros/nuevo.html
+++ b/src/main/resources/templates/registros/nuevo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Registros', 'Nuevo', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Registros', 'Nuevo', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
     <div class="card shadow-sm p-4">
         <h5 class="mb-4">

--- a/src/main/resources/templates/usuarios/edicion.html
+++ b/src/main/resources/templates/usuarios/edicion.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Usuarios', 'Editar', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Usuarios', 'Editar', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
 
     <div class="card shadow-sm p-4">

--- a/src/main/resources/templates/usuarios/index.html
+++ b/src/main/resources/templates/usuarios/index.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Usuarios', 'Listado', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org"
+	  th:replace="fragments/layout :: layoutBase('Usuarios', 'Listado', ~{::contenido}, ~{::scripts})">
+
 <th:block th:fragment="contenido">
 	<div class="row">
 		<div class="col-12">
@@ -16,12 +18,12 @@
 					</a>
 				</div>
 
-				<form method="get" th:action="@{/usuarios/filtrado}" th:object="${filtro}">
-					<div class="row g-2 px-4 pt-3">
+				<div class="row g-2 px-4 pt-3 d-flex justify-content-between align-items-center">
+					<form method="get" th:action="@{/usuarios/filtrado}" th:object="${filtro}" class="d-flex flex-wrap gap-2 col">
 						<!-- Select de Roles -->
 						<div class="col-auto">
 							<div class="input-group input-group-sm">
-								<span class="input-group-text bg-white border-secondary">
+								<span class="input-group-text border-secondary">
 									<i class="fa-solid fa-user-tag text-secondary"></i>
 								</span>
 								<select class="form-select border-secondary" th:field="*{idRol}" id="idRol" onchange="this.form.submit()">
@@ -33,13 +35,24 @@
 
 						<!-- Botón Limpiar -->
 						<div class="col-auto">
-							<a th:href="@{/usuarios}" class="btn btn-outline-secondary btn-sm d-flex align-items-center">
-								<i class="fa-solid fa-arrows-rotate me-1"></i>
+							<a th:href="@{/usuarios}" class="btn btn-outline-secondary btn-sm mb-0">
+								<i class="fa-solid fa-broom me-1"></i>
 								Limpiar
 							</a>
 						</div>
+					</form>
+
+					<div class="col-auto d-flex gap-2">
+						<button id="btn-exportar-pdf" class="btn btn-danger btn-sm mb-0">
+							<i class="fa-solid fa-file-pdf me-1"></i>
+							PDF
+						</button>
+						<button id="btn-exportar-excel" class="btn btn-success btn-sm mb-0">
+							<i class="fa-solid fa-file-excel me-1"></i>
+							Excel
+						</button>
 					</div>
-				</form>
+				</div>
 
 				<div class="card-body px-0 pt-0 pb-2">
 					<table id="tabla-usuarios" class="table align-items-center mb-0">
@@ -113,8 +126,6 @@
 		</div>
 	</div>
 
-	<div th:replace="fragments/datatable-script :: datatableScript('tabla-usuarios')"></div>
-
 	<!-- SweetAlert para confirmación -->
 	<script>
 		function confirmarEliminacion(id) {
@@ -137,5 +148,24 @@
 
 	<!-- Mostrar alertas -->
 	<div th:utext="${alert}"></div>
+</th:block>
+
+<th:block th:fragment="scripts">
+	<div th:replace="fragments/datatable-script :: datatableScript('tabla-usuarios')"></div>
+
+	<!-- jsPDF + autoTable -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
+
+	<!-- ExcelJS -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/exceljs/4.3.0/exceljs.min.js"></script>
+
+	<script>
+		// ===================== Export to PDF =====================
+        // =================== End Export to PDF ===================
+
+        // ===================== Export to Excel =====================
+        // ================== End Export to Excel ==================
+	</script>
 </th:block>
 </html>

--- a/src/main/resources/templates/usuarios/nuevo.html
+++ b/src/main/resources/templates/usuarios/nuevo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Usuarios', 'Nuevo', ~{::contenido})">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layoutBase('Usuarios', 'Nuevo', ~{::contenido}, ~{})">
 <th:block th:fragment="contenido">
 
     <div class="card shadow-sm p-4">


### PR DESCRIPTION
**What's included:**

1. Added working export to PDF and Excel in the Clients (/clientes) view.
2. Both exports include styling, borders, headers, date/time, and are based on filtered DataTable rows.
3. Integrated jsPDF and ExcelJS with custom styles matching system branding.