### PR TITLE
♻️ refactor: rename field 'Estado' to 'Activo' in Cliente table

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -24,13 +24,13 @@ CREATE TABLE Cliente (
     Nombre VARCHAR(255) NOT NULL,
     Apellido VARCHAR(255) NOT NULL,
     Telefono VARCHAR(9) NOT NULL,
-    Estado BOOLEAN NOT NULL DEFAULT TRUE
+    Activo BOOLEAN NOT NULL DEFAULT TRUE
 );
 
 CREATE TABLE Plan (
     IdPlan INT PRIMARY KEY AUTO_INCREMENT,
     Descripcion VARCHAR(255) NOT NULL,
-    Activo Bit default 1
+    Activo BIT DEFAULT 1
 );
 
 CREATE TABLE Promocion (

--- a/src/main/java/com/sistema/gpon/model/Cliente.java
+++ b/src/main/java/com/sistema/gpon/model/Cliente.java
@@ -36,6 +36,6 @@ public class Cliente {
 	@Pattern(regexp = "\\d{9}", message = "El teléfono debe tener 9 dígitos")
 	private String telefono;
 
-	@Column(name = "Estado", nullable = false)
-	private Boolean estado;
+	@Column(name = "Activo", nullable = false)
+	private Boolean activo;
 }

--- a/src/main/java/com/sistema/gpon/service/impl/ClienteServiceImpl.java
+++ b/src/main/java/com/sistema/gpon/service/impl/ClienteServiceImpl.java
@@ -68,7 +68,7 @@ public class ClienteServiceImpl implements ClienteService {
     @Override
     public ResultadoResponse cambiarEstado(String id) {
         Cliente cliente = this.buscarPorId(id);
-        Boolean accion = cliente.getEstado() ? false : true;
+        Boolean accion = cliente.getActivo() ? false : true;
         String texto;
 
         if (accion == true) {
@@ -77,7 +77,7 @@ public class ClienteServiceImpl implements ClienteService {
             texto = "ha sido inactivado";
         }
 
-        cliente.setEstado(!cliente.getEstado());
+        cliente.setActivo(!cliente.getActivo());
 
         try {
             Cliente registrado = clienteRepository.save(cliente);

--- a/src/main/resources/templates/clientes/edicion.html
+++ b/src/main/resources/templates/clientes/edicion.html
@@ -62,7 +62,7 @@
                 </div>
 
                 <!-- Estado (oculto)-->
-                <input type="hidden" th:field="*{estado}" />
+                <input type="hidden" th:field="*{activo}" />
             </div>
 
             <!-- Botones -->

--- a/src/main/resources/templates/clientes/index.html
+++ b/src/main/resources/templates/clientes/index.html
@@ -67,12 +67,12 @@
                                         <div class="d-flex align-items-center gap-2">
                                             <div class="form-switch">
                                                 <input class="form-check-input" type="checkbox"
-                                                       th:checked="${cliente.estado}" onchange="this.form.submit()">
+                                                       th:checked="${cliente.activo}" onchange="this.form.submit()">
                                             </div>
                                         </div>
                                     </form>
 
-                                    <span class="d-none export-estado" th:text="${cliente.estado} ? 'Sí' : 'No'"></span>
+                                    <span class="d-none export-estado" th:text="${cliente.activo} ? 'Sí' : 'No'"></span>
                                 </td>
                                 <td class="ps-0">
                                     <a th:href="@{'/clientes/edicion/' + ${cliente.dniCliente}}" class="btn btn-sm text-primary me-1 mb-0">


### PR DESCRIPTION
This PR updates the Cliente table schema by renaming the Estado column to Activo for improved clarity and consistency across the database. This change aligns the field name with its actual purpose (indicating active status) and follows the naming convention used in other tables like Plan.