### PR TITLE
🐛 fix: correct variable name in th:each from x to s for supervisors dropdown rendering in Thymeleaf

### DIFF
--- a/src/main/resources/templates/registros/nuevo.html
+++ b/src/main/resources/templates/registros/nuevo.html
@@ -45,7 +45,7 @@
                         </label>
                         <select th:field="*{idUsuarioSupervisor}" class="form-select" required>
                             <option value="">Seleccione un supervisor</option>
-                            <option th:each="x : ${supervisores}"
+                            <option th:each="s : ${supervisores}"
                                     th:value="${s.idUsuario}"
                                     th:text="${s.nombre + ' ' + s.apellido}">
                             </option>


### PR DESCRIPTION
Fixed incorrect iterator variable in th:each, ensuring proper rendering of supervisor options.